### PR TITLE
Add 'quarter' chart scale for large date ranges

### DIFF
--- a/components/Line.jsx
+++ b/components/Line.jsx
@@ -153,7 +153,12 @@ var Line = React.createClass({
 
         var labels = [];
 
-        if (interval >= 85) {
+        if (interval >= 365) {
+            // QUARTER
+            interval_format = '[Q]Q YY';
+            interval_type= 'quarter';
+        }
+        else if (interval >= 85) {
             // MONTHS
             interval_format = 'MMM YY';
             interval_type = 'month';


### PR DESCRIPTION
Quick fix for crowded horizontal scale --
Show by 'quarters' [ eg. Q1 -Q4 ] when date range queried is more than a year. 
