### PR TITLE
Bump to 0.3.6; fix column series data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bd-peanut",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "React chart components",
   "main": "peanut.js",
   "scripts": {


### PR DESCRIPTION
Patch update to 0.3.6 version —
Fix series data inside 'column' component.
